### PR TITLE
feat(ui): add Export button to download generated code as HTML (Closes #24)

### DIFF
--- a/nextjs-web-app/src/app/results/page.tsx
+++ b/nextjs-web-app/src/app/results/page.tsx
@@ -15,6 +15,7 @@ import PromptInput from "@/components/DevTools/PromptInput";
 import VoiceInput from "@/components/DevTools/VoiceInput";
 import FullscreenPreview from "@/components/FullscreenPreview";
 import MockDeployButton from "@/components/MockDeployButton";
+import ExportButton from "@/components/ExportButton";
 import { SignupModal } from "@/components/SignupModal";
 import styled from "styled-components";
 
@@ -338,10 +339,17 @@ function ResultsContent() {
                           theme={theme}
                           onMaximize={handleMaximize}
                           deployButton={
-                            <MockDeployButton
-                              code={editedResults[selectedAppIndex] || ""}
-                              theme={theme}
-                            />
+                            <>
+                              <ExportButton
+                                code={editedResults[selectedAppIndex] || ""}
+                                theme={theme}
+                                filename={`${appTitles[selectedAppIndex].replace(/\s+/g, '-').toLowerCase()}.html`}
+                              />
+                              <MockDeployButton
+                                code={editedResults[selectedAppIndex] || ""}
+                                theme={theme}
+                              />
+                            </>
                           }
                         />
                       </div>

--- a/nextjs-web-app/src/components/ExportButton.tsx
+++ b/nextjs-web-app/src/components/ExportButton.tsx
@@ -1,0 +1,44 @@
+import { motion } from 'framer-motion';
+import { FaDownload } from 'react-icons/fa';
+
+interface ExportButtonProps {
+  code: string;
+  theme: 'light' | 'dark';
+  filename?: string;
+}
+
+export default function ExportButton({ code, theme, filename = 'app.html' }: ExportButtonProps) {
+  const handleExport = () => {
+    try {
+      const blob = new Blob([code], { type: 'text/html;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      console.error('Failed to export code', e);
+    }
+  };
+
+  return (
+    <motion.button
+      onClick={handleExport}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className={`flex items-center gap-1 px-3 py-1 rounded-md text-sm ${
+        theme === 'dark'
+          ? 'bg-gray-800 hover:bg-gray-700 text-gray-300'
+          : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
+      }`}
+      title="Download HTML"
+    >
+      <FaDownload className="w-3 h-3 mr-1" />
+      Export
+    </motion.button>
+  );
+}
+


### PR DESCRIPTION
Summary
- Add Export button to download the currently selected generated app as an HTML file
- Place next to Deploy in the detailed view header on Results page
- Implemented lightweight ExportButton component using Blob + URL.createObjectURL

Files changed
- nextjs-web-app/src/components/ExportButton.tsx (new)
- nextjs-web-app/src/app/results/page.tsx (import + integrate ExportButton)

E2E Validation (local)
- Built with `npm run build` successfully
- Launched server with `npm run start`
- Navigated to `/results` (no prompt) to render the detailed view
- Verified Export button is visible
- Clicked Export; intercepted `URL.createObjectURL` in Playwright MCP and observed it being called (indicates download flow triggered)

Notes
- Keeps UI consistent with existing buttons (theme-aware styling)
- Exports the selected app code as `<title>.html` (lowercased, hyphenated)
- Non-invasive change; no backend dependency

Closes #24

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author